### PR TITLE
Remove batch processing

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -14,4 +14,4 @@ require 'wikidata/fetcher'
 ]
 
 names = @pages.map { |c| WikiData::Category.new(c, 'cs').member_titles }.flatten.uniq
-EveryPolitician::Wikidata.scrape_wikidata(names: { cs: names }, batch_size: 125)
+EveryPolitician::Wikidata.scrape_wikidata(names: { cs: names })


### PR DESCRIPTION
Scraper was failing with timeouts possible caused by a failing batch fetch.

This commit removes batch processing. (Batch processing was introduced to save
memory but is not needed after recent wikisnakker update
(https://github.com/everypolitician/wikisnakker/pull/50 ))

Removes batch_size argument from EveryPolitician::Wikidata.scrape_wikidata
